### PR TITLE
Update for Ubuntu 12.04 LTS Compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.0)
 project(DLMS-COSEM)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 add_subdirectory(src)
 INCLUDE(InstallRequiredSystemLibraries)

--- a/README
+++ b/README
@@ -5,4 +5,8 @@ cd build
 cmake ..
 make
 
+If this fails with not finding the Asio installation folder,
 
+Define the _Asio_INCLUDE_DIRS environment variable to be the path to your installation.
+   Or define via the cmake command line:
+       cmake .. -D_Asio_INCLUDE_DIRS=MyFolder

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.0)
 set(EXECUTABLE_NAME "countdown")
 find_package(Asio REQUIRED)
-include_directories(${Asio_INCLUDE_DIRS})
+include_directories(${ASIO_INCLUDE_DIR})
 add_executable(${EXECUTABLE_NAME} main.cpp)
 INSTALL(TARGETS ${EXECUTABLE_NAME} DESTINATION bin)


### PR DESCRIPTION
Project would not build on my configuration.  It still doesn't build completely, because of lack of C++14 support in the standard 12.04 gcc.  But, this configuration should work on computers that have the latest gcc.
